### PR TITLE
Remove useless IIDM dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,14 +56,14 @@
         <maven.site.version>3.7.1</maven.site.version>
         <maven.surefire.version>2.22.2</maven.surefire.version>
 
+        <commonslang3.version>3.4</commonslang3.version>
         <jgrapht.version>1.0.1</jgrapht.version>
         <junit.version>4.12</junit.version>
         <lombok.version>1.18.8</lombok.version>
         <mockito.version>2.28.2</mockito.version>
         <springboot.version>2.2.5.RELEASE</springboot.version>
         <springfox.version>2.9.2</springfox.version>
-
-        <powsyblcore.version>3.0.0</powsyblcore.version>
+        <supercsv.version>2.4.0</supercsv.version>
     </properties>
 
     <dependencyManagement>
@@ -91,6 +91,16 @@
             <version>${springfox.version}</version>
         </dependency>
         <dependency>
+            <groupId>net.sf.supercsv</groupId>
+            <artifactId>super-csv</artifactId>
+            <version>${supercsv.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commonslang3.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
             <version>${jgrapht.version}</version>
@@ -107,12 +117,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-iidm-api</artifactId>
-            <version>${powsyblcore.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/src/main/java/org/gridsuite/odre/server/client/OdreCsvClientImpl.java
+++ b/src/main/java/org/gridsuite/odre/server/client/OdreCsvClientImpl.java
@@ -7,7 +7,6 @@
 package org.gridsuite.odre.server.client;
 
 import com.google.common.collect.Lists;
-import com.powsybl.iidm.network.Country;
 import org.gridsuite.odre.server.dto.Coordinate;
 import org.gridsuite.odre.server.dto.LineGeoData;
 import org.gridsuite.odre.server.dto.SubstationGeoData;
@@ -82,7 +81,7 @@ public class OdreCsvClientImpl implements OdreClient {
 
                 SubstationGeoData substation = substations.get(id);
                 if (substation == null) {
-                    SubstationGeoData substationGeoData = new SubstationGeoData(id, Country.FR, new Coordinate(lat, lon));
+                    SubstationGeoData substationGeoData = new SubstationGeoData(id, "FR", new Coordinate(lat, lon));
                     substations.put(id, substationGeoData);
                 }
 
@@ -160,7 +159,7 @@ public class OdreCsvClientImpl implements OdreClient {
 
                 if (ends.size() == 2) {
                     List<Coordinate> coordinates = Lists.newArrayList(new BreadthFirstIterator<>(graph, ends.get(0)));
-                    LineGeoData line = new LineGeoData(lineId, Country.FR, Country.FR, coordinates);
+                    LineGeoData line = new LineGeoData(lineId, "FR", "FR", coordinates);
                     lines.put(lineId, line);
                 } else {
                     oneConnectedSetDiscarded++;
@@ -184,7 +183,7 @@ public class OdreCsvClientImpl implements OdreClient {
                 }
 
                 List<Coordinate> aggregatedCoordinates =  aggregateCoordinates(coordinatesComponents);
-                LineGeoData line = new LineGeoData(lineId, Country.FR, Country.FR, aggregatedCoordinates);
+                LineGeoData line = new LineGeoData(lineId, "FR", "FR", aggregatedCoordinates);
                 lines.put(lineId, line);
             }
         }

--- a/src/main/java/org/gridsuite/odre/server/dto/LineGeoData.java
+++ b/src/main/java/org/gridsuite/odre/server/dto/LineGeoData.java
@@ -6,7 +6,6 @@
  */
 package org.gridsuite.odre.server.dto;
 
-import com.powsybl.iidm.network.Country;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -22,9 +21,9 @@ public class LineGeoData {
 
     private  String id;
 
-    private Country country1;
+    private String country1;
 
-    private Country country2;
+    private String country2;
 
     private List<Coordinate> coordinates;
 }

--- a/src/main/java/org/gridsuite/odre/server/dto/SubstationGeoData.java
+++ b/src/main/java/org/gridsuite/odre/server/dto/SubstationGeoData.java
@@ -6,7 +6,6 @@
  */
 package org.gridsuite.odre.server.dto;
 
-import com.powsybl.iidm.network.Country;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -19,7 +18,7 @@ public class SubstationGeoData {
 
     private String id;
 
-    private Country country;
+    private String country;
 
     private Coordinate coordinate;
 }

--- a/src/test/java/org/gridsuite/odre/server/dto/LineGeoDataTest.java
+++ b/src/test/java/org/gridsuite/odre/server/dto/LineGeoDataTest.java
@@ -6,7 +6,6 @@
  */
 package org.gridsuite.odre.server.dto;
 
-import com.powsybl.iidm.network.Country;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -21,11 +20,11 @@ public class LineGeoDataTest {
 
     @Test
     public void test() {
-        LineGeoData lineGeoData = new LineGeoData("l", Country.FR, Country.FR, new ArrayList<>());
+        LineGeoData lineGeoData = new LineGeoData("l", "FR", "FR", new ArrayList<>());
 
         assertEquals("l", lineGeoData.getId());
-        assertEquals(Country.FR, lineGeoData.getCountry1());
-        assertEquals(Country.FR, lineGeoData.getCountry2());
+        assertEquals("FR", lineGeoData.getCountry1());
+        assertEquals("FR", lineGeoData.getCountry2());
         assertTrue(lineGeoData.getCoordinates().isEmpty());
     }
 }

--- a/src/test/java/org/gridsuite/odre/server/dto/SubstationGeoDataTest.java
+++ b/src/test/java/org/gridsuite/odre/server/dto/SubstationGeoDataTest.java
@@ -6,7 +6,6 @@
  */
 package org.gridsuite.odre.server.dto;
 
-import com.powsybl.iidm.network.Country;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -19,10 +18,10 @@ public class SubstationGeoDataTest {
 
     @Test
     public void test() {
-        SubstationGeoData substationGeoData = new SubstationGeoData("id", Country.FR, new Coordinate(1, 1));
+        SubstationGeoData substationGeoData = new SubstationGeoData("id", "FR", new Coordinate(1, 1));
 
         assertEquals("id", substationGeoData.getId());
-        assertEquals(Country.FR, substationGeoData.getCountry());
+        assertEquals("FR", substationGeoData.getCountry());
         assertEquals(new Coordinate(1, 1), substationGeoData.getCoordinate());
     }
 }

--- a/src/test/java/org/gridsuite/odre/server/services/OdreServiceImplTest.java
+++ b/src/test/java/org/gridsuite/odre/server/services/OdreServiceImplTest.java
@@ -6,7 +6,6 @@
  */
 package org.gridsuite.odre.server.services;
 
-import com.powsybl.iidm.network.Country;
 import org.gridsuite.odre.server.client.OdreClient;
 import org.gridsuite.odre.server.dto.Coordinate;
 import org.gridsuite.odre.server.dto.LineGeoData;
@@ -18,7 +17,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
@@ -45,18 +43,18 @@ public class OdreServiceImplTest {
     @Before
     public void setUp() {
         List<SubstationGeoData> substationGeoData = new ArrayList<>();
-        substationGeoData.add(new SubstationGeoData("substation1", Country.FR, new Coordinate(1, 2)));
-        substationGeoData.add(new SubstationGeoData("substation2", Country.FR, new Coordinate(3, 4)));
-        substationGeoData.add(new SubstationGeoData("substation3", Country.FR, new Coordinate(5, 6)));
+        substationGeoData.add(new SubstationGeoData("substation1", "FR", new Coordinate(1, 2)));
+        substationGeoData.add(new SubstationGeoData("substation2", "FR", new Coordinate(3, 4)));
+        substationGeoData.add(new SubstationGeoData("substation3", "FR", new Coordinate(5, 6)));
 
         List<LineGeoData> lineGeoData = new ArrayList<>();
-        lineGeoData.add(new LineGeoData("lines1", Country.FR, Country.FR,
+        lineGeoData.add(new LineGeoData("lines1", "FR", "FR",
                 Arrays.asList(new Coordinate(2, 3), new Coordinate(3, 4))));
 
-        lineGeoData.add(new LineGeoData("lines2", Country.FR, Country.BE,
+        lineGeoData.add(new LineGeoData("lines2", "FR", "BE",
                 Arrays.asList(new Coordinate(1, 3), new Coordinate(5, 3))));
 
-        lineGeoData.add(new LineGeoData("lines3", Country.FR, Country.GE,
+        lineGeoData.add(new LineGeoData("lines3", "FR", "GE",
                 Arrays.asList(new Coordinate(4, 3), new Coordinate(2, 3), new Coordinate(7, 4))));
 
         Mockito.when(client.getSubstations())


### PR DESCRIPTION
ODRE server depends on IIDM (an oudated version) for only Country enum, which is always FR in case of ODRE data. We remove this useless dependency to avoid taking case of updating it for just a FR enum. 

Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>