### PR TITLE
cleanup: remove unreachable code

### DIFF
--- a/src/main/java/org/gridsuite/odre/server/utils/GeographicDataParser.java
+++ b/src/main/java/org/gridsuite/odre/server/utils/GeographicDataParser.java
@@ -210,9 +210,7 @@ public final class GeographicDataParser {
         double l1 = getBranchLength(coordinatesComponent1);
         double l2 = getBranchLength(coordinatesComponent2);
 
-        if (100 * l1 / l2 < THRESHOLD) {
-            return coordinatesComponent2;
-        } else if (100 * l2 / l1 < THRESHOLD) {
+        if (100 * l2 / l1 < THRESHOLD) {
             return coordinatesComponent1;
         }
 


### PR DESCRIPTION
the components were just sorted before so l1 > l2 so l1/l2 can not be less than the threshold